### PR TITLE
build: ignore generated tex-svg-full.js (Issue #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ package-lock.json
 # Misc
 _sass/vendors
 assets/js/dist
+
+# MathJax / KaTeX generated files
+tex-svg-full.js


### PR DESCRIPTION
## 요약
- Jekyll/MathJax 빌드 과정에서 자동 생성되는 `tex-svg-full.js`가
  Git에 추적되어 브랜치 이동 및 PR을 방해하던 문제를 해결했습니다.

## 변경 내용
- `.gitignore`에 `tex-svg-full.js` 추가
- 빌드 재실행 후 Git 상태 clean 확인

## 확인 사항
- [x] 로컬 Jekyll build 정상 동작
- [x] 빌드 후 git status clean
- [x] 브랜치 이동 시 자동 변경 파일 없음

Closes #26
